### PR TITLE
bugfix/fix-path-in-share: exclude the root folders from path.

### DIFF
--- a/archive/ziparchive.go
+++ b/archive/ziparchive.go
@@ -15,6 +15,7 @@
 package archive
 
 import (
+	"github.com/jemurai/s3s2/options"
 	"archive/zip"
 	"io"
 	"os"
@@ -27,8 +28,9 @@ import (
 // ZipFile archives the provided list of files into a Zip file.
 // This is functional but not currently used in S3S2 in favor of
 // the Zst archive format which is faster and better compression.
-func ZipFile(filename string) string {
+func ZipFile(filename string, options options.Options) string {
 	zfilename := filename + ".zip"
+	log.Debugf("The file name is " + zfilename)
 	newZipFile, err := os.Create(zfilename)
 	if err != nil {
 		log.Error(err)
@@ -57,7 +59,7 @@ func ZipFile(filename string) string {
 
 	// Using FileInfoHeader() above only uses the basename of the file. If we want
 	// to preserve the folder structure we can overwrite this with the full path.
-	header.Name = filename
+	header.Name = strings.Replace(filename, options.Directory, "", -1)
 
 	// Change to deflate to gain better compression
 	// see http://golang.org/pkg/archive/zip/#pkg-constants
@@ -94,7 +96,7 @@ func UnZipFile(filename string, destination string) string {
 			log.Fatal(err)
 		}
 		defer zippedFile.Close()
-
+		log.Debugf("this is the files name from zreader " + file.Name)
 		extractedFilePath := filepath.Join(
 			destination,
 			file.Name,

--- a/cmd/share.go
+++ b/cmd/share.go
@@ -49,7 +49,7 @@ that it will be encrypted.`,
 		folder := opts.Prefix + "_s3s2_" + fnuuid.String()
 		m := manifest.BuildManifest(folder, opts)
 
-		if err := s3helper.UploadFile(folder, m.Name, opts); err != nil {
+		if err := s3helper.UploadFile(folder, opts.Directory + m.Name, opts); err != nil {
 			log.Error(err)
 		}
 		var wg sync.WaitGroup
@@ -69,7 +69,7 @@ that it will be encrypted.`,
 func processFile(folder string, fn string, options options.Options) {
 	log.Debugf("Processing %s", fn)
 	start := time.Now()
-	fn = archive.ZipFile(fn)
+	fn = archive.ZipFile(options.Directory + fn, options)
 	//fn = archive.ZipFile(fn)
 	archiveTime := timing(start, "\tArchive time (sec): %f")
 	log.Debugf("\tCompressing file: %s", fn)

--- a/manifest/manifest.go
+++ b/manifest/manifest.go
@@ -76,7 +76,7 @@ func BuildManifest(folder string, options options.Options) Manifest {
 			}
 			if !info.IsDir() && !strings.HasSuffix(path, "manifest.json") {
 				sha256hash := hash(path)
-				files = append(files, FileDescription{path, info.Size(), info.ModTime(), sha256hash})
+				files = append(files, FileDescription{strings.Replace(path, options.Directory, "", -1), info.Size(), info.ModTime(), sha256hash})
 			}
 			return nil
 		})
@@ -87,7 +87,7 @@ func BuildManifest(folder string, options options.Options) Manifest {
 	user, err := user.Current()
 	sudoUser := os.Getenv("SUDO_USER") // In case they are sudo'ing, we can know the acting user.
 	manifest := Manifest{
-		Name:         filepath.Clean(options.Directory + "/s3s2_manifest.json"),
+		Name:         filepath.Clean("/s3s2_manifest.json"),
 		Timestamp:    time.Now(),
 		Organization: options.Org,
 		Username:     user.Name,

--- a/s3/s3helper.go
+++ b/s3/s3helper.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	options "github.com/jemurai/s3s2/options"
 	log "github.com/sirupsen/logrus"
@@ -49,7 +50,7 @@ func UploadFile(folder string, filename string, options options.Options) error {
 	if options.AwsKey != "" {
 		result, err := uploader.Upload(&s3manager.UploadInput{
 			Bucket:               aws.String(options.Bucket),
-			Key:                  aws.String(filepath.Clean(folder + "/" + f.Name())),
+			Key:                  aws.String(filepath.Clean(folder + "/" + strings.Replace(f.Name(), options.Directory, "", -1))),
 			ServerSideEncryption: aws.String("aws:kms"),
 			SSEKMSKeyId:          aws.String(options.AwsKey),
 			Body:                 f,
@@ -61,7 +62,7 @@ func UploadFile(folder string, filename string, options options.Options) error {
 	} else {
 		result, err := uploader.Upload(&s3manager.UploadInput{
 			Bucket: aws.String(options.Bucket),
-			Key:    aws.String(filepath.Clean(folder + "/" + f.Name())),
+			Key:    aws.String(filepath.Clean(folder + "/" + strings.Replace(f.Name(), options.Directory, "", -1))),
 			Body:   f,
 		})
 		if err != nil {


### PR DESCRIPTION
1.  I came across an issue when I share file or folder it preserves the whole directory path passed from the command like for example if Directory = "/tmp/adx/xyz/data" for example while executing `s3s2 share --debug true --bucket bucket --region us-west-2 --directory /opt/xyz/data --org OrganizationXYZ --prefix org_batch --receiver-public-key /opt/xyz/s3s2_keys/test.pubkey` It saves the folder and files as `s3://bucket/org_batch/opt/xyz/data`, however when sharing it should be usually `s3://bucket/org_batch` with files and directory inside folder(shared, in this case data folder) structure preserved. 

2. Manifest.json also retains the path name in filename. 
